### PR TITLE
fix(auth): Corrige lógica de sessão e adiciona tipagem

### DIFF
--- a/src/utils/authDB.ts
+++ b/src/utils/authDB.ts
@@ -1,4 +1,10 @@
-import { initAuthCreds, BufferJSON, proto } from '@itsukichan/baileys';
+import {
+  initAuthCreds,
+  BufferJSON,
+  proto,
+  AuthenticationState,
+  SignalDataTypeMap,
+} from '@itsukichan/baileys';
 import BaileysSession from '../database/models/BaileysSession.js';
 export async function useSequelizeAuthState(botId: number) {
   const row = await BaileysSession.findOne({ where: { botId } });
@@ -14,31 +20,28 @@ export async function useSequelizeAuthState(botId: number) {
   };
 
   const keys = {
-    get: async (type: string, ids: string[]) => {
-      const data: Record<string, any> = {};
-      await Promise.all(
-        ids.map(async (id) => {
-          let value = saved.keys?.[type]?.[id] || null;
-          if (type === 'app-state-sync-key' && value) {
-            value = proto.Message.AppStateSyncKeyData.fromObject(data);
-          }
-          data[id] = value;
-        }),
-      );
+    get: async <T extends keyof SignalDataTypeMap>(type: T, ids: string[]): Promise<{ [key: string]: SignalDataTypeMap[T] }> => {
+      const data: { [key: string]: SignalDataTypeMap[T] } = {};
+      for (const id of ids) {
+        let value = saved.keys?.[type]?.[id];
+        if (type === 'app-state-sync-key' && value) {
+          value = proto.Message.AppStateSyncKeyData.fromObject(value);
+        }
+        data[id] = value;
+      }
       return data;
     },
-    set: async (data: Record<string, Record<string, any>>) => {
-      for (const category of Object.keys(data)) {
-        saved.keys = saved.keys || {};
-        saved.keys[category] = saved.keys[category] || {};
-        for (const id of Object.keys(data[category])) {
-          saved.keys[category][id] = data[category][id] || null;
-        }
+
+    set: async (data: Partial<AuthenticationState['keys']>) => {
+      for (const _key in data) {
+        const key = _key as keyof AuthenticationState['keys'];
+        saved.keys[key] = saved.keys[key] || {};
+        Object.assign(saved.keys[key], data[key]);
       }
       await writeSession();
     },
   };
-  const state = { creds: saved.creds, keys };
+  const state: AuthenticationState = { creds: saved.creds, keys };
   const saveCreds = async () => {
     await writeSession();
   };


### PR DESCRIPTION
Esta alteração aborda duas questões importantes no gerenciamento da sessão do Baileys:

1.  **Correção do erro `rate-overlimit`:** O bot enfrentava um erro de `rate-overlimit` ao tentar se reconectar após um período offline. A causa era um bug na função `useSequelizeAuthState` que corrompia a chave de sincronização (`app-state-sync-key`) durante a restauração da sessão, forçando uma nova autenticação desnecessária. A lógica foi corrigida para garantir que a sessão seja restaurada corretamente.

2.  **Adição de Tipagem Explícita:** Para melhorar a qualidade e a segurança do código, foram adicionados os tipos explícitos do Baileys (`AuthenticationState`, `SignalDataTypeMap`) às funções `get` e `set` e outras variáveis em `src/utils/authDB.ts`. Isso elimina o uso de `any` implícito e fortalece a verificação de tipos do TypeScript.

Com essas mudanças, o bot se torna mais estável e o código, mais robusto e fácil de manter.